### PR TITLE
major: Update googleapis to v58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3095,9 +3095,9 @@
       }
     },
     "gaxios": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.4.tgz",
-      "integrity": "sha512-97NmFuMETFQh6gqPUxkqjxRMjmY8aRKRMphIkgO/b90AbCt5wAVuXsp8oWjIXlLN2pIK/fsXD8edcM7ULkFMLg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.1.0.tgz",
+      "integrity": "sha512-DDTn3KXVJJigtz+g0J3vhcfbDbKtAroSTxauWsdnP57sM5KZ3d2c/3D9RKFJ86s43hfw6WULg6TXYw/AYiBlpA==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -3233,9 +3233,9 @@
       }
     },
     "google-auth-library": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.5.tgz",
-      "integrity": "sha512-Wj31lfTm2yR4g3WfOOB1Am1tt478Xq9OvzTPQJi17tn/I9R5IcsxjANBsE93nYmxYxtwDedhOdIb8l3vSPG49Q==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.6.tgz",
+      "integrity": "sha512-fWYdRdg55HSJoRq9k568jJA1lrhg9i2xgfhVIMJbskUmbDpJGHsbv9l41DGhCDXM21F9Kn4kUwdysgxSYBYJUw==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -3285,9 +3285,9 @@
       }
     },
     "googleapis": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-57.0.0.tgz",
-      "integrity": "sha512-QTeh4/i1xsueUVRzVZ3zYIfckPnmSpVeBIkWGh1BJtXUrUapaVMIp+wuJ3Z10anHwvy+n24ypBtuuRX0oR7dPQ==",
+      "version": "58.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-58.0.0.tgz",
+      "integrity": "sha512-gfpv+8Fr8TCO6yMCTrQUySZe2IJDM/6lulUAh3RuYYPlUBdd3g1B2zMkd7Ot59P6CyGYt4ZMzTLpyHVoLxM85w==",
       "requires": {
         "google-auth-library": "^6.0.0",
         "googleapis-common": "^4.4.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bluebird": "^3.7.2",
     "blueimp-md5": "^2.17.0",
     "fast-json-patch": "^3.0.0-1",
-    "googleapis": "^57.0.0",
+    "googleapis": "^58.0.0",
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.19",
     "moment": "^2.27.0",


### PR DESCRIPTION
Potential breaking change

Change-type: major
Signed-off-by: Graham McCulloch <graham@balena.io>
***

Note: This major version should only be added to Jellyfish in [this PR](https://github.com/product-os/jellyfish/pull/4558). Subsequent updates should not be merged until Jellyfish is also using googleapis v58.
