### PR TITLE
Adds query for the user's roles to the send-first-time-login-link action

### DIFF
--- a/lib/handlers/action-send-first-time-login-link.js
+++ b/lib/handlers/action-send-first-time-login-link.js
@@ -47,6 +47,34 @@ const queryUserOrgs = async ({
 	})
 }
 
+const getUserRoles = async ({
+	userId, context, request
+}) => {
+	const [ user ] = await context.query(context.privilegedSession, {
+		type: 'object',
+		properties: {
+			id: {
+				const: userId
+			},
+			data: {
+				type: 'object',
+				properties: {
+					roles: {
+						type: 'array',
+						items: {
+							type: 'string'
+						}
+					}
+				}
+			}
+		}
+	})
+	const roles = _.get(user, [ 'data', 'roles' ])
+	assert.USER(request.context, roles, context.errors.WorkerNoElement,
+		'Something went wrong while trying to query for the user\'s roles')
+	return roles
+}
+
 const invalidatePreviousFirstTimeLogins = async ({
 	context,
 	request,
@@ -236,7 +264,12 @@ const handler = async (session, context, userCard, request) => {
 		userCard,
 		context
 	})
-	if (userCard.data.roles.length === 0) {
+	const userRoles = await getUserRoles({
+		userId: userCard.id,
+		request,
+		context
+	})
+	if (userRoles.length === 0) {
 		logger.info(request.context, `User with slug ${userCard.slug} has no role set. Adding community role now`)
 		await addCommunityRoleToUser({
 			session,


### PR DESCRIPTION
We are expecting the user to be passed to the handler with the roles attached. A change in the frontend means that the roles are no longer passed in. It seemed to me that the backend shouldn't rely on this data being available in the frontend so I have added a query for the roles here