### PR TITLE
Add action-set-update action to the action-library

### DIFF
--- a/lib/actions/action-set-update.js
+++ b/lib/actions/action-set-update.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+module.exports = {
+	slug: 'action-set-update',
+	type: 'action@1.0.0',
+	version: '1.0.0',
+	name: 'Update a field on a card',
+	markers: [],
+	tags: [],
+	links: {},
+	active: true,
+	data: {
+		filter: {
+			type: 'object'
+		},
+		arguments: {
+			property: {
+				type: 'string'
+			},
+			value: {
+				type: [
+					'string',
+					'number',
+					'array'
+				]
+			}
+		}
+	},
+	requires: [],
+	capabilities: []
+}

--- a/lib/handlers/action-set-update.js
+++ b/lib/handlers/action-set-update.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+
+const handler = async (session, context, card, request) => {
+	const typeCard = await context.getCardBySlug(
+		session, card.type)
+
+	const path = _.isString(request.arguments.property)
+		? `/${request.arguments.property.replace(/\./g, '/')}`
+		: `/${request.arguments.property.join('/')}`
+
+	const current = _.get(card, request.arguments.property)
+
+	const result = await context.patchCard(session, typeCard, {
+		timestamp: request.timestamp,
+		actor: request.actor,
+		originator: request.originator,
+		attachEvents: true
+	}, card, [
+		{
+			op: current ? 'replace' : 'add',
+			path,
+			value: request.arguments.value
+		}
+	])
+
+	if (!result) {
+		return null
+	}
+
+	return {
+		id: result.id,
+		type: result.type,
+		version: result.version,
+		slug: result.slug
+	}
+}
+
+module.exports = {
+	handler
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -102,6 +102,11 @@ module.exports = {
 		pre: _.noop,
 		handler: require('./handlers/action-set-add').handler
 	},
+	'action-set-update': {
+		card: require('./actions/action-set-update'),
+		pre: _.noop,
+		handler: require('./handlers/action-set-update').handler
+	},
 	'action-delete-card': {
 		card: require('./actions/action-delete-card'),
 		pre: _.noop,


### PR DESCRIPTION
This is necessary for adding/updating the latest_event_created_at field on a support-thread and other cards using the with-events mixin. It creates a patch and runs this on the supplied card

Change-type: minor
Signed-off-by: Lucy-Jane Walsh <lucy-jane@balena.io>