### PR TITLE
Update send-first-time-login-link action handler

### DIFF
--- a/lib/handlers/action-send-first-time-login-link.js
+++ b/lib/handlers/action-send-first-time-login-link.js
@@ -236,7 +236,8 @@ const addCommunityRoleToUser = async ({
 	session,
 	context,
 	userCard,
-	request
+	request,
+	userRoles
 }) => {
 	const typeCard = await context.getCardBySlug(session, 'user@latest')
 	await context.patchCard(context.privilegedSession, typeCard, {
@@ -248,7 +249,7 @@ const addCommunityRoleToUser = async ({
 		{
 			op: 'replace',
 			path: '/data/roles',
-			value: [ 'user-community' ]
+			value: userRoles.concat([ 'user-community' ])
 		}
 	])
 	logger.info(request.context, `Added community role to user with slug ${userCard.slug}`)
@@ -271,13 +272,15 @@ const handler = async (session, context, userCard, request) => {
 		request,
 		context
 	})
-	if (userRoles.length === 0) {
-		logger.info(request.context, `User with slug ${userCard.slug} has no role set. Adding community role now`)
+	const containsCommunityRole = _.includes(userRoles, 'user-community')
+	if (!containsCommunityRole) {
+		logger.info(request.context, `User with slug ${userCard.slug} does not have community role. Adding role now`)
 		await addCommunityRoleToUser({
 			session,
 			context,
 			userCard,
-			request
+			request,
+			userRoles
 		})
 	}
 


### PR DESCRIPTION
All users we send the first-time-login token to needs to have the community role set so they can actually use Jellyfish.

This PR checks explicitly whether the user has the `user-community` role. Adds to existing roles if it is not present.

This is to solve the case where the user already has a role like `external-support-agent` (happens when we have synced the user from balena-api). Before we were only adding the `user-community role` when the roles field was an empty list. Now we check that the list includes `user-community` and add its if it doesn't

I have added a test for this to the Jellyfish repo which should pass with this update
