### PR TITLE
Allow optional pattern matching in syncContext.getElementByMirrorId()

### DIFF
--- a/lib/handlers/sync-context.js
+++ b/lib/handlers/sync-context.js
@@ -126,7 +126,7 @@ exports.fromWorkerContext = (provider, workerContext, context, session) => {
 		getElementById: async (id) => {
 			return workerContext.getCardById(session, id)
 		},
-		getElementByMirrorId: async (type, mirrorId) => {
+		getElementByMirrorId: async (type, mirrorId, options = {}) => {
 			assert.INTERNAL(context, mirrorId,
 				Error, 'You must supply a mirrorId as key')
 
@@ -146,7 +146,10 @@ exports.fromWorkerContext = (provider, workerContext, context, session) => {
 						properties: {
 							mirrors: {
 								type: 'array',
-								contains: {
+								contains: options.usePattern ? {
+									type: 'string',
+									pattern: mirrorId
+								} : {
 									type: 'string',
 									const: mirrorId
 								}

--- a/lib/handlers/sync-context.spec.js
+++ b/lib/handlers/sync-context.spec.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) Balena.io - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ * Proprietary and confidential.
+ */
+
+const _ = require('lodash')
+const ava = require('ava')
+const {
+	fromWorkerContext
+} = require('./sync-context')
+const skhema = require('skhema')
+
+const makeWorkerContextStub = (cardFixtures) => {
+	return {
+		query: (_session, schema) => {
+			return _.filter(cardFixtures, (card) => {
+				return skhema.isValid(schema, card)
+			})
+		}
+	}
+}
+
+ava('context.getElementByMirrorId() should match mirrors exactly', async (test) => {
+	const mirrorId = 'test://1'
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://2'
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = fromWorkerContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', mirrorId)
+
+	test.deepEqual(result, card1)
+})
+
+ava('context.getElementByMirrorId() should match by type', async (test) => {
+	const mirrorId = 'test://1'
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'foo',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = fromWorkerContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', mirrorId)
+
+	test.deepEqual(result, card1)
+})
+
+ava('context.getElementByMirrorId() should not return anything if there is no match', async (test) => {
+	const mirrorId = 'test://1'
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				mirrorId
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://2'
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = fromWorkerContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', 'foobarbaz')
+
+	test.falsy(result)
+})
+
+ava('context.getElementByMirrorId() should optionally use a pattern match for the mirror Id', async (test) => {
+	const card1 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://foo/1'
+			]
+		}
+	}
+
+	const card2 = {
+		type: 'card',
+		data: {
+			mirrors: [
+				'test://bar/2'
+			]
+		}
+	}
+
+	const workerContextStub = makeWorkerContextStub([
+		card1,
+		card2
+	])
+
+	const context = fromWorkerContext({}, workerContextStub, {}, '')
+
+	const result = await context.getElementByMirrorId('card', 'foo/1', {
+		usePattern: true
+	})
+
+	test.deepEqual(result, card1)
+})


### PR DESCRIPTION
This change allows sync integrations to specify mirror IDs as patternns
instead of `const` values. This is really useful for situations like
Front, where the mirror ID was previously a fully qualified URL and we
need to change it to a more stable format.

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>