### PR TITLE
No longer skip setting user avatar when null

### DIFF
--- a/lib/actions/action-set-user-avatar.ts
+++ b/lib/actions/action-set-user-avatar.ts
@@ -9,7 +9,7 @@ import { getLogger } from '@balena/jellyfish-logger';
 import type { ActionFile } from '@balena/jellyfish-plugin-base';
 import md5 from 'blueimp-md5';
 import get from 'lodash/get';
-import has from 'lodash/has';
+import isNil from 'lodash/isNil';
 import requestP from 'request-promise';
 
 const logger = getLogger(__filename);
@@ -51,7 +51,7 @@ const handler: ActionFile['handler'] = async (
 	const email = get(card, ['data', 'email']);
 
 	// If a gravatar value is already set or the user has no email, exit early
-	if (!email || has(card, ['data', 'avatar'])) {
+	if (!email || !isNil(get(card, ['data', 'avatar']))) {
 		return {
 			id: card.id,
 			slug: card.slug,


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Resolves #760 

Attempt to set a user's avatar even when `data.avatar` is already set to `null`. The current implementation skips setting the avatar when `data.avatar` is set to anything, including `null`. This means that `data.avatar` doesn't get set when a user updates their `data.email` to one that is linked to a valid Gravatar.