### PR TITLE
update-card: Return contract summary on no changes

### DIFF
--- a/lib/actions/action-update-card.ts
+++ b/lib/actions/action-update-card.ts
@@ -37,7 +37,12 @@ const handler: ActionFile['handler'] = async (
 	);
 
 	if (!result) {
-		return null;
+		return {
+			id: card.id,
+			type: card.type,
+			version: card.version,
+			slug: card.slug,
+		};
 	}
 
 	return {

--- a/test/integration/actions/action-update-card.spec.ts
+++ b/test/integration/actions/action-update-card.spec.ts
@@ -72,4 +72,37 @@ describe('handler()', () => {
 			request.arguments.patch[0].value,
 		);
 	});
+
+	test('should return contract summary even when nothing is updated', async () => {
+		const message = await context.kernel.insertCard(
+			context.context,
+			context.session,
+			makeMessage(context),
+		);
+		const request = makeRequest(context, {
+			patch: [
+				{
+					op: 'replace',
+					path: '/data/payload/message',
+					value: message.data.payload.message,
+				},
+			],
+		});
+
+		expect.assertions(2);
+		const result = await handler(context.session, context, message, request);
+		if (!isNull(result) && !isArray(result)) {
+			expect(result).toEqual({
+				id: message.id,
+				type: message.type,
+				version: message.version,
+				slug: message.slug,
+			});
+		}
+
+		const updated = await context.getCardById(context.session, message.id);
+		expect(updated.data.payload.message).toEqual(
+			request.arguments.patch[0].value,
+		);
+	});
 });


### PR DESCRIPTION
Change-type: major
Signed-off-by: Josh Bowling

---

Changes the `update-card` action, returning the summary of the contract in question when the patch operation doesn't change anything on the contract. The current implementation returns `null`, even though some kind of response is usually expected, and causes an error to be thrown in `jellyfish-client-sdk`: https://github.com/product-os/jellyfish-client-sdk/blob/master/lib/index.ts#L778

Ran some tests and found that `null` is returned from `context.patchCard()` when the provided patch doesn't actually update anything on the contract. Errors, such as `JellyfishNoElement: No such card` are thrown as expected when passing a nonexistent card ID to this action meaning that `result` and `!result` are unrelated to error checks.

Hoping that this is a valid solution to the problems causing consistent CI failures here: https://github.com/product-os/jellyfish/pull/6345