### PR TITLE
Add optional loop field to action-create-card args

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,4 +7,5 @@
 module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "node",
+	testTimeout: 10000
 };

--- a/lib/actions/action-create-card.ts
+++ b/lib/actions/action-create-card.ts
@@ -147,6 +147,10 @@ export const actionCreateCard: ActionFile = {
 								pattern: '^[a-zA-Z0-9-_/:+]+$',
 							},
 						},
+						loop: {
+							// TODO: Add pattern once the format of loop slugs has been finalized
+							type: ['string', 'null'],
+						},
 						tags: {
 							type: 'array',
 							items: {

--- a/package.json
+++ b/package.json
@@ -99,8 +99,5 @@
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"
-  },
-  "jest": {
-    "testTimeout": "10000"
   }
 }


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Graham McCulloch <graham@balena.io>

***

This is necessary before we add the top-level `loop` field to the base contract definition - otherwise all create-card actions will fail.