### PR TITLE
Move CI environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,5 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
-LOGLEVEL ?= info
-export LOGLEVEL
-INTEGRATION_DEFAULT_USER ?= admin
-export INTEGRATION_DEFAULT_USER
-
-DATABASE ?= postgres
-export DATABASE
-POSTGRES_USER ?= $(shell whoami)
-export POSTGRES_USER
-POSTGRES_PASSWORD ?=
-export POSTGRES_PASSWORD
-POSTGRES_PORT ?= 5432
-export POSTGRES_PORT
-POSTGRES_HOST ?= localhost
-export POSTGRES_HOST
-POSTGRES_DATABASE ?= jellyfish
-export POSTGRES_DATABASE
-
-REDIS_NAMESPACE ?= $(SERVER_DATABASE)
-export REDIS_NAMESPACE
-REDIS_PASSWORD ?=
-export REDIS_PASSWORD
-REDIS_PORT ?= 6379
-export REDIS_PORT
-REDIS_HOST ?= localhost
-export REDIS_HOST
-
-INTEGRATION_GOOGLE_MEET_CREDENTIALS ?= {}
-export INTEGRATION_GOOGLE_MEET_CREDENTIALS
-MAIL_TYPE ?= mailgun
-export MAIL_TYPE
-MAILGUN_TOKEN ?=
-export MAILGUN_TOKEN
-MAILGUN_DOMAIN ?= mail.ly.fish
-export MAILGUN_DOMAIN
-MAILGUN_BASE_URL = https://api.mailgun.net/v3
-export MAILGUN_BASE_URL
-
 # Define make commands that wrap npm scripts to ensure a more consistent workflow across repos
 .PHONY: clean
 clean:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,12 @@ services:
       - REDIS_HOST=redis
       - REDIS_PASSWORD=
       - REDIS_PORT=6379
+      - MAIL_TYPE=mailgun
+      - MAILGUN_DOMAIN=mail.ly.fish
+      - MAILGUN_BASE_URL=https://api.mailgun.net/v3
+      - MAILGUN_TOKEN
+      - INTEGRATION_DEFAULT_USER=admin
+      - INTEGRATION_GOOGLE_MEET_CREDENTIALS={}
       - CI=1
       - NPM_TOKEN
     networks:


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Move some env vars from `Makefile` to `docker-compose.test.yml`.