### PR TITLE
Add test.env file for compose tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,13 +21,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PASSWORD=
       - REDIS_PORT=6379
-      - MAIL_TYPE=mailgun
-      - MAILGUN_DOMAIN=mail.ly.fish
-      - MAILGUN_BASE_URL=https://api.mailgun.net/v3
-      - MAILGUN_TOKEN
-      - INTEGRATION_DEFAULT_USER=admin
-      - INTEGRATION_GOOGLE_MEET_CREDENTIALS
       - CI=1
       - NPM_TOKEN
+    env_file:
+      - test.env
     networks:
       - internal

--- a/test.env
+++ b/test.env
@@ -1,0 +1,7 @@
+# This dotenv file is used with docker-compose.test.yml for testing purposes.
+MAIL_TYPE=mailgun
+MAILGUN_DOMAIN=mail.ly.fish
+MAILGUN_BASE_URL=https://api.mailgun.net/v3
+MAILGUN_TOKEN
+INTEGRATION_DEFAULT_USER=admin
+INTEGRATION_GOOGLE_MEET_CREDENTIALS


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Adds a `test.env` file to be used with `docker-compose.test.yml` for testing. The idea  is to keep environment variables that are shared among all repos in `docker-compose.test.yml` and keep others in `test.env`. This will allow us to sync a singled shared `docker-compose.test.yml` file from `jellyfish-config`.