### PR TITLE
Fix username pattern for password reset request

### DIFF
--- a/lib/actions/action-request-password-reset.ts
+++ b/lib/actions/action-request-password-reset.ts
@@ -322,7 +322,7 @@ export const actionRequestPasswordReset: ActionFile = {
 			arguments: {
 				username: {
 					type: 'string',
-					pattern: '[a-z0-9-]+$',
+					pattern: '^[a-z0-9-]+$',
 				},
 			},
 		},

--- a/test/integration/actions/action-request-password-reset.spec.ts
+++ b/test/integration/actions/action-request-password-reset.spec.ts
@@ -692,4 +692,25 @@ describe('action-request-password-reset', () => {
 		expect(passwordReset.error).toBe(false);
 		expect(includes('to', firstEmail, context.mailBody)).toBe(true);
 	});
+
+	test('should throw error when provided username is an email address', async () => {
+		expect.hasAssertions();
+		context.nockRequest();
+
+		const requestPasswordResetAction = {
+			action: 'action-request-password-reset@1.0.0',
+			context: context.context,
+			card: context.user.data.id,
+			type: context.user.data.type,
+			arguments: {
+				username: 'foo@bar.com',
+			},
+		};
+
+		try {
+			await context.processAction(context.session, requestPasswordResetAction);
+		} catch (error: any) {
+			expect(error.name).toEqual('WorkerSchemaMismatch');
+		}
+	});
 });


### PR DESCRIPTION
Without this fix invalid strings can be passed as username, such as
email addresses. This results in the action quietly failing and then
confusing the user when the password reset email doesn't arrive.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>