### PR TITLE
Migrate action tests from main repo

### DIFF
--- a/test/integration/actions/action-send-first-time-login-link.spec.ts
+++ b/test/integration/actions/action-send-first-time-login-link.spec.ts
@@ -637,4 +637,36 @@ describe('action-send-first-time-login-link', () => {
 		assert(updated);
 		expect(updated.data.roles).toEqual(roles);
 	});
+
+	test('users with the "user-community" role cannot send a first-time login link to another user', async () => {
+		const targetUser = await ctx.createUser(ctx.generateRandomID());
+		const communityUser = await ctx.createUser(ctx.generateRandomID());
+		await ctx.createLink(
+			ctx.actor.id,
+			ctx.session,
+			targetUser.contract,
+			balenaOrg,
+			'is member of',
+			'has member',
+		);
+		await ctx.createLink(
+			ctx.actor.id,
+			ctx.session,
+			communityUser.contract,
+			balenaOrg,
+			'is member of',
+			'has member',
+		);
+
+		await expect(
+			handler(
+				communityUser.session,
+				actionContext,
+				targetUser.contract,
+				makeRequest(ctx),
+			),
+		).rejects.toThrow(
+			new ctx.worker.errors.WorkerNoElement('No such type: first-time-login'),
+		);
+	});
 });


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Moved *most* tests from https://github.com/product-os/jellyfish/blob/a8338df1c8285ed40f5f3894714122c6d638314f/test/e2e/server/security/community.spec.js