### PR TITLE
Test removing secrets from AWS

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,6 +6,7 @@
 
 import { JellyfishPluginBase } from '@balena/jellyfish-plugin-base';
 import actions from './actions';
+
 // tslint:disable-next-line: no-var-requires
 const { version } = require('../package.json');
 


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Do not merge. Testing that all tests pass after removing secrets from the AWS parameter store. CI should be using git secrets alone and not depending on the AWS parameter store any longer.