### PR TITLE
Use privileged session to get types

### DIFF
--- a/lib/actions/action-complete-first-time-login.ts
+++ b/lib/actions/action-complete-first-time-login.ts
@@ -93,7 +93,7 @@ export async function invalidateFirstTimeLogin(
 	card: Contract,
 ): Promise<Contract> {
 	const typeCard = (await context.getCardBySlug(
-		session,
+		context.privilegedSession,
 		'first-time-login@latest',
 	))! as TypeContract;
 	return (await context.patchCard(

--- a/lib/actions/action-complete-password-reset.ts
+++ b/lib/actions/action-complete-password-reset.ts
@@ -97,7 +97,7 @@ export async function invalidatePasswordReset(
 	passwordResetCard: Contract,
 ): Promise<Contract> {
 	const typeCard = (await context.getCardBySlug(
-		session,
+		context.privilegedSession,
 		'password-reset@1.0.0',
 	))! as TypeContract;
 	return (await context.patchCard(


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Found this in production logs pertaining to the `complete-password-reset` action failing:
```
HTTP unexpected error {"name":"TypeError","message":"Cannot read property 'slug' of null","stack":"TypeError: Cannot read property 'slug' of null\n    at Worker.patchCard (/usr/src/jellyfish/apps/server/node_modules/@balena/jellyfish-worker/build/index.js:331:28)\n    at Object.patchCard (/usr/src/jellyfish/apps/server/node_modules/@balena/jellyfish-worker/build/index.js:230:29)\n    at invalidatePasswordReset (/usr/src/jellyfish/apps/server/node_modules/@balena/jellyfish-action-library/build/actions/action-complete-password-reset.js:101:27)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)\n    at async handler (/usr/src/jellyfish/apps/server/node_modules/@balena/jellyfish-action-library/build/actions/action-complete-password-reset.js:118:5)\n    at async Worker.execute (/usr/src/jellyfish/apps/server/node_modules/@balena/jellyfish-worker/build/index.js:733:26)\n    at async /usr/src/jellyfish/apps/server/build/bootstrap.js:164:13\n    at async actionRequest (/usr/src/jellyfish/apps/server/node_modules/@balena/jellyfish-queue/build/consumer.js:98:29)\n    at async doNext (/usr/src/jellyfish/apps/server/node_modules/graphile-worker/dist/worker.js:184:17)"}
```

From the error output, we understand that `jellyfish-worker/build/index.js:331` is throwing, complaining that it cannot get `slug` property from `null`. Taking a look at the built version of `jellyfish-worker`, this appears to be referring to `typeCard.slug`:
![worker-type](https://user-images.githubusercontent.com/45343541/143408505-41944c84-ecf9-4036-906d-3c73e0d2c923.png)

When we look again at where `typeCard` is obtained, it is in the `invalidatePasswordReset()` function at `action-complete-password-reset.js:100` using the passed in `session` parameter instead of `context.privilegedSession`:
![action-type](https://user-images.githubusercontent.com/45343541/143409324-3610e51f-45af-40c3-8bbb-577a7895d679.png)

This makes me think that `typeCard` at this point is `null`, even though we know it exists in the database (manually double-checked production database just in case).