### PR TITLE
Use privileged session in more places

### DIFF
--- a/lib/actions/action-complete-first-time-login.ts
+++ b/lib/actions/action-complete-first-time-login.ts
@@ -88,7 +88,6 @@ export async function getFirstTimeLoginCard(
  */
 export async function invalidateFirstTimeLogin(
 	context: WorkerContext,
-	session: string,
 	request: ActionRequest,
 	card: Contract,
 ): Promise<Contract> {
@@ -97,7 +96,7 @@ export async function invalidateFirstTimeLogin(
 		'first-time-login@latest',
 	))! as TypeContract;
 	return (await context.patchCard(
-		session,
+		context.privilegedSession,
 		typeCard,
 		{
 			timestamp: request.timestamp,
@@ -135,12 +134,7 @@ const handler: ActionFile['handler'] = async (
 		throw error;
 	}
 
-	await invalidateFirstTimeLogin(
-		context,
-		context.privilegedSession,
-		request,
-		firstTimeLogin,
-	);
+	await invalidateFirstTimeLogin(context, request, firstTimeLogin);
 
 	const [user] =
 		firstTimeLogin &&

--- a/lib/actions/action-complete-password-reset.ts
+++ b/lib/actions/action-complete-password-reset.ts
@@ -92,7 +92,6 @@ export async function getPasswordResetCard(
  */
 export async function invalidatePasswordReset(
 	context: WorkerContext,
-	session: string,
 	request: ActionRequest,
 	passwordResetCard: Contract,
 ): Promise<Contract> {
@@ -101,7 +100,7 @@ export async function invalidatePasswordReset(
 		'password-reset@1.0.0',
 	))! as TypeContract;
 	return (await context.patchCard(
-		session,
+		context.privilegedSession,
 		typeCard,
 		{
 			timestamp: request.timestamp,
@@ -134,7 +133,7 @@ const handler: ActionFile['handler'] = async (
 		'Reset token invalid',
 	);
 
-	await invalidatePasswordReset(context, session, request, passwordReset);
+	await invalidatePasswordReset(context, request, passwordReset);
 
 	const [user] =
 		passwordReset.links && passwordReset.links['is attached to']

--- a/test/integration/actions/action-complete-first-time-login.spec.ts
+++ b/test/integration/actions/action-complete-first-time-login.spec.ts
@@ -105,7 +105,7 @@ describe('action-complete-first-time-login', () => {
 				newPassword,
 			},
 		});
-		await ctx.processAction(ctx.session, completeFirstTimeLoginAction);
+		await ctx.processAction(user.session, completeFirstTimeLoginAction);
 
 		const updated = await ctx.jellyfish.getCardById(
 			ctx.context,

--- a/test/integration/actions/action-complete-password-reset.spec.ts
+++ b/test/integration/actions/action-complete-password-reset.spec.ts
@@ -115,7 +115,7 @@ describe('action-complete-password-reset', () => {
 			},
 		});
 		const completePasswordResetResult = await ctx.processAction(
-			ctx.session,
+			user.session,
 			completePasswordReset,
 		);
 		expect(completePasswordResetResult.error).toBe(false);


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Original thread: https://www.flowdock.com/app/rulemotion/p-cyclops/threads/ucqnmY4Ka6ZVO5J-PwNXfOA7RZx

We're seeing `No such card: password-reset-a44828ec-c1b3-4b4c-bd2f-004c286bbc51@1.0.0` errors in production logs on attempts to reset user passwords even though the contract in question does in fact exist. Was able to reproduce this error in integration tests in this repo by executing `ctx.processAction()` with `user.session` instead of `ctx.session`:
![diff](https://user-images.githubusercontent.com/45343541/143541490-d7243b01-db9f-4a9f-9fdd-0cb81089f95c.png)

The changes in this PR ensures that the privileged session is used where needed and that the tests better reflect reality (executing with user session).