### PR TITLE
Export `ActionLibrary` using the `export` statement

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -6,7 +6,7 @@ const { version } = require('../package.json');
 /**
  * The Action Library Jellyfish plugin.
  */
-class ActionLibrary extends JellyfishPluginBase {
+export class ActionLibrary extends JellyfishPluginBase {
 	constructor() {
 		super({
 			slug: 'action-library',
@@ -16,5 +16,3 @@ class ActionLibrary extends JellyfishPluginBase {
 		});
 	}
 }
-
-export = ActionLibrary;

--- a/test/integration/actions/action-broadcast.spec.ts
+++ b/test/integration/actions/action-broadcast.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { cloneDeep, isArray, isNull, map, pick, sortBy } from 'lodash';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionBroadcast } from '../../../lib/actions/action-broadcast';
 
 const handler = actionBroadcast.handler;

--- a/test/integration/actions/action-complete-first-time-login.spec.ts
+++ b/test/integration/actions/action-complete-first-time-login.spec.ts
@@ -6,7 +6,7 @@ import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import nock from 'nock';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionCompleteFirstTimeLogin } from '../../../lib/actions/action-complete-first-time-login';
 import { PASSWORDLESS_USER_HASH } from '../../../lib/actions/constants';
 

--- a/test/integration/actions/action-complete-password-reset.spec.ts
+++ b/test/integration/actions/action-complete-password-reset.spec.ts
@@ -9,7 +9,7 @@ import crypto from 'crypto';
 import { isArray, isNull } from 'lodash';
 import nock from 'nock';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionCompletePasswordReset } from '../../../lib/actions/action-complete-password-reset';
 
 const ACTIONS = defaultEnvironment.actions;

--- a/test/integration/actions/action-create-card.spec.ts
+++ b/test/integration/actions/action-create-card.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionCreateCard } from '../../../lib/actions/action-create-card';
 
 const handler = actionCreateCard.handler;

--- a/test/integration/actions/action-create-event.spec.ts
+++ b/test/integration/actions/action-create-event.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionCreateEvent } from '../../../lib/actions/action-create-event';
 
 const handler = actionCreateEvent.handler;

--- a/test/integration/actions/action-create-session.spec.ts
+++ b/test/integration/actions/action-create-session.spec.ts
@@ -5,7 +5,7 @@ import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import bcrypt from 'bcrypt';
 import { isArray, isNull } from 'lodash';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionCreateSession } from '../../../lib/actions/action-create-session';
 import { BCRYPT_SALT_ROUNDS } from '../../../lib/actions/constants';
 

--- a/test/integration/actions/action-create-user.spec.ts
+++ b/test/integration/actions/action-create-user.spec.ts
@@ -7,7 +7,7 @@ import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import bcrypt from 'bcrypt';
 import { isArray, isNull } from 'lodash';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionCreateUser } from '../../../lib/actions/action-create-user';
 import { PASSWORDLESS_USER_HASH } from '../../../lib/actions/constants';
 

--- a/test/integration/actions/action-delete-card.spec.ts
+++ b/test/integration/actions/action-delete-card.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionDeleteCard } from '../../../lib/actions/action-delete-card';
 
 const handler = actionDeleteCard.handler;

--- a/test/integration/actions/action-google-meet.spec.ts
+++ b/test/integration/actions/action-google-meet.spec.ts
@@ -5,7 +5,7 @@ import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { google } from 'googleapis';
 import sinon from 'sinon';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionGoogleMeet } from '../../../lib/actions/action-google-meet';
 
 const handler = actionGoogleMeet.handler;

--- a/test/integration/actions/action-increment-tag.spec.ts
+++ b/test/integration/actions/action-increment-tag.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { pick } from 'lodash';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionIncrementTag } from '../../../lib/actions/action-increment-tag';
 
 const handler = actionIncrementTag.handler;

--- a/test/integration/actions/action-increment.spec.ts
+++ b/test/integration/actions/action-increment.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionIncrement } from '../../../lib/actions/action-increment';
 
 const handler = actionIncrement.handler;

--- a/test/integration/actions/action-integration-import-event.spec.ts
+++ b/test/integration/actions/action-integration-import-event.spec.ts
@@ -7,7 +7,7 @@ import { isArray } from 'lodash';
 import sinon from 'sinon';
 import { makeRequest } from './helpers';
 import { FoobarPlugin } from './plugin';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionIntegrationImportEvent } from '../../../lib/actions/action-integration-import-event';
 
 const source = 'foobar';

--- a/test/integration/actions/action-merge-draft-version.spec.ts
+++ b/test/integration/actions/action-merge-draft-version.spec.ts
@@ -6,7 +6,7 @@ import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
 import * as semver from 'semver';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionMergeDraftVersion } from '../../../lib/actions/action-merge-draft-version';
 
 const handler = actionMergeDraftVersion.handler;

--- a/test/integration/actions/action-oauth-associate.spec.ts
+++ b/test/integration/actions/action-oauth-associate.spec.ts
@@ -5,7 +5,7 @@ import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
 import * as integration from './integrations/foobar';
 import { FoobarPlugin } from './plugin';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionOAuthAssociate } from '../../../lib/actions/action-oauth-associate';
 
 const handler = actionOAuthAssociate.handler;

--- a/test/integration/actions/action-oauth-authorize.spec.ts
+++ b/test/integration/actions/action-oauth-authorize.spec.ts
@@ -8,7 +8,7 @@ import nock from 'nock';
 import sinon from 'sinon';
 import * as integration from './integrations/foobar';
 import { FoobarPlugin } from './plugin';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionOAuthAuthorize } from '../../../lib/actions/action-oauth-authorize';
 
 const handler = actionOAuthAuthorize.handler;

--- a/test/integration/actions/action-ping.spec.ts
+++ b/test/integration/actions/action-ping.spec.ts
@@ -3,7 +3,7 @@ import { DefaultPlugin } from '@balena/jellyfish-plugin-default';
 import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionPing } from '../../../lib/actions/action-ping';
 
 const handler = actionPing.handler;

--- a/test/integration/actions/action-request-password-reset.spec.ts
+++ b/test/integration/actions/action-request-password-reset.spec.ts
@@ -5,7 +5,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import nock from 'nock';
 import { includes } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { PASSWORDLESS_USER_HASH } from '../../../lib/actions/constants';
 
 const MAIL_OPTIONS = defaultEnvironment.mail.options;

--- a/test/integration/actions/action-send-email.spec.ts
+++ b/test/integration/actions/action-send-email.spec.ts
@@ -4,7 +4,7 @@ import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { get } from 'lodash';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionSendEmail } from '../../../lib/actions/action-send-email';
 
 const handler = actionSendEmail.handler;

--- a/test/integration/actions/action-send-first-time-login-link.spec.ts
+++ b/test/integration/actions/action-send-first-time-login-link.spec.ts
@@ -6,7 +6,7 @@ import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import nock from 'nock';
 import { includes, makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionSendFirstTimeLoginLink } from '../../../lib/actions/action-send-first-time-login-link';
 
 const MAIL_OPTIONS = defaultEnvironment.mail.options;

--- a/test/integration/actions/action-set-add.spec.ts
+++ b/test/integration/actions/action-set-add.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionSetAdd } from '../../../lib/actions/action-set-add';
 
 const handler = actionSetAdd.handler;

--- a/test/integration/actions/action-set-password.spec.ts
+++ b/test/integration/actions/action-set-password.spec.ts
@@ -3,7 +3,7 @@ import { DefaultPlugin } from '@balena/jellyfish-plugin-default';
 import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import bcrypt from 'bcrypt';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import {
 	BCRYPT_SALT_ROUNDS,
 	PASSWORDLESS_USER_HASH,

--- a/test/integration/actions/action-set-update.spec.ts
+++ b/test/integration/actions/action-set-update.spec.ts
@@ -4,7 +4,7 @@ import { ProductOsPlugin } from '@balena/jellyfish-plugin-product-os';
 import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionSetUpdate } from '../../../lib/actions/action-set-update';
 
 const handler = actionSetUpdate.handler;

--- a/test/integration/actions/action-set-user-avatar.spec.ts
+++ b/test/integration/actions/action-set-user-avatar.spec.ts
@@ -7,7 +7,7 @@ import md5 from 'blueimp-md5';
 import { isArray, isNull } from 'lodash';
 import nock from 'nock';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionSetUserAvatar } from '../../../lib/actions/action-set-user-avatar';
 
 const handler = actionSetUserAvatar.handler;

--- a/test/integration/actions/action-update-card.spec.ts
+++ b/test/integration/actions/action-update-card.spec.ts
@@ -5,7 +5,7 @@ import { integrationHelpers } from '@balena/jellyfish-test-harness';
 import type { WorkerContext } from '@balena/jellyfish-types/build/worker';
 import { isArray, isNull } from 'lodash';
 import { makeRequest } from './helpers';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { actionUpdateCard } from '../../../lib/actions/action-update-card';
 
 const handler = actionUpdateCard.handler;

--- a/test/integration/actions/mirror.spec.ts
+++ b/test/integration/actions/mirror.spec.ts
@@ -7,7 +7,7 @@ import { isArray, isEmpty } from 'lodash';
 import sinon from 'sinon';
 import { makeRequest } from './helpers';
 import { FoobarPlugin } from './plugin';
-import ActionLibrary from '../../../lib';
+import { ActionLibrary } from '../../../lib';
 import { mirror } from '../../../lib/actions/mirror';
 
 const source = 'foobar';

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -1,5 +1,5 @@
 import { isEmpty, isPlainObject } from 'lodash';
-import ActionLibrary from '../../lib/index';
+import { ActionLibrary } from '../../lib/index';
 
 const context = {
 	id: 'jellyfish-action-library-test',


### PR DESCRIPTION
As it was this module could only be imported with a `require`.

Change-type: major
Signed-off-by: Carol Schulze <carol@balena.io>